### PR TITLE
Fix: Don't Show NProgressBar When An Error Occurs If Not in Flight

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -284,7 +284,7 @@ const NextTopLoader = ({
       } catch (err) {
         // Log the error in development only!
         // console.log('NextTopLoader error: ', err);
-        NProgress.start();
+        
         NProgress.done();
       }
     }


### PR DESCRIPTION
This PR fixes the scenario when an error is thrown on document click and the progress still shows.

## Description
This is a problem, especially when you click an empty area and the anchor returns null, the progress still shows, making the entire page seemingly act as a link. In order to curb that, the NProgress,start() function was removed and this acts as normal once again


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
It has been tested locally and with production code

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.

